### PR TITLE
cli: added automatic docs generation for Rest-API

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,22 +6,55 @@ on:
       - 'sprint*'    # matches sprint0, sprint1, etc
 permissions:
   contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore dependencies
+        working-directory: ./isopruefi-backend
+        run: dotnet restore
+
+      - name: Restore tools
+        working-directory: ./isopruefi-backend
+        run: dotnet tool restore --tool-manifest .config/dotnet-tools.json
+
+      - name: Install mkdocs2md
+        working-directory: ./isopruefi-backend
+        run: dotnet tool install -g Nefarius.Tools.XMLDoc2Markdown
+
+      - name: Build
+        working-directory: ./isopruefi-backend
+        run: dotnet build --no-restore
+
+      - name: Generate Rest Documentation
+        working-directory: ./isopruefi-backend/Rest-API
+        run: dotnet tool run xmldoc2md ./bin/Debug/net9.0/Rest-API.dll ../../isopruefi-docs/docs/code/Rest-API
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
-          
-      - uses: actions/cache@v4
+
+      - name: Cache MkDocs dependencies
+        uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: |
             mkdocs-material
 
-      - run: pip install -r ./isopruefi-docs/requirements.txt
-      - run: cd ./isopruefi-docs && mkdocs gh-deploy --force
+      - name: Install Python requirements
+        run: pip install -r ./isopruefi-docs/requirements.txt
+
+      - name: Deploy documentation to GitHub Pages
+        run: |
+          cd ./isopruefi-docs
+          mkdocs gh-deploy --force


### PR DESCRIPTION
This pull request updates the `.github/workflows/docs.yml` file to enhance the documentation deployment workflow by integrating .NET-based tools for generating REST API documentation and improving the overall structure of the pipeline.

### Workflow Enhancements:

* Replaced the `actions/setup-python@v5` step with a new `.NET` setup step using `actions/setup-dotnet@v4`, specifying `.NET` version `9.0.x`.
* Added steps to restore `.NET` dependencies and tools (`dotnet restore` and `dotnet tool restore`) within the `isopruefi-backend` directory.
* Introduced a new step to install the `Nefarius.Tools.XMLDoc2Markdown` tool globally for generating REST API documentation.
* Added a build step (`dotnet build --no-restore`) and a step to generate REST API documentation using the `xmldoc2md` tool.

### Python Workflow Adjustments:

* Reorganized the Python setup and dependency installation steps, ensuring they occur after the .NET-related steps.
* Improved the MkDocs deployment step by adding a named step for deploying documentation to GitHub Pages.