### PR TITLE
Fix/fix doc generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,17 +26,13 @@ jobs:
         working-directory: ./isopruefi-backend
         run: dotnet tool restore --tool-manifest .config/dotnet-tools.json
 
-      - name: Install mkdocs2md
-        working-directory: ./isopruefi-backend
-        run: dotnet tool install -g Nefarius.Tools.XMLDoc2Markdown
-
       - name: Build
         working-directory: ./isopruefi-backend
         run: dotnet build --no-restore
 
       - name: Generate Rest Documentation
         working-directory: ./isopruefi-backend/Rest-API
-        run: xmldoc2md ./bin/Debug/net9.0/Rest-API.dll ../../isopruefi-docs/docs/code/Rest-API
+        run: dotnet xmldoc2md ./bin/Debug/net9.0/Rest-API.dll ../../isopruefi-docs/docs/code/Rest-API
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Generate Rest Documentation
         working-directory: ./isopruefi-backend/Rest-API
-        run: dotnet tool run xmldoc2md ./bin/Debug/net9.0/Rest-API.dll ../../isopruefi-docs/docs/code/Rest-API
+        run: xmldoc2md ./bin/Debug/net9.0/Rest-API.dll ../../isopruefi-docs/docs/code/Rest-API
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/isopruefi-backend/.config/dotnet-tools.json
+++ b/isopruefi-backend/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "dotnet-ef"
       ],
       "rollForward": false
+    },
+    "nefarius.tools.xmldoc2markdown": {
+      "version": "1.6.1",
+      "commands": [
+        "xmldoc2md"
+      ],
+      "rollForward": false
     }
   }
 }


### PR DESCRIPTION
This pull request updates the process for generating REST API documentation by modifying the use of the `xmldoc2md` tool. The changes streamline the workflow by replacing a global tool installation with a local tool configuration.

### Workflow updates:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL29-R35): Removed the step to globally install the `xmldoc2md` tool and updated the documentation generation step to use the locally configured tool instead.

### Tool configuration:

* [`isopruefi-backend/.config/dotnet-tools.json`](diffhunk://#diff-c6e68bca82d12b1b90e0111eda2dfefb41f34a22d839a50c373ae4ca43ebb92aR18-R24): Added the `nefarius.tools.xmldoc2markdown` tool with version `1.6.1` to the local tool manifest, enabling its use without global installation.