### PR TITLE
fix: fixed typo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet xmldoc2md ./bin/Debug/net9.0/MQTT-Sender.dll ../../isopruefi-docs/docs/code/MQTT-Sender
 
       - name: Generate UnitTest Documentation
-        working-directory: ./isopruefi-backend/MQTT-Sender
+        working-directory: ./isopruefi-backend/UnitTests
         run: dotnet xmldoc2md ./bin/Debug/net9.0/UnitTests.dll ../../isopruefi-docs/docs/code/UnitTests
 
       - name: Setup Python


### PR DESCRIPTION
This pull request updates the `.github/workflows/docs.yml` file to correct the working directory for generating unit test documentation.

* Workflow configuration:
  * Updated the `working-directory` for the "Generate UnitTest Documentation" step from `./isopruefi-backend/MQTT-Sender` to `./isopruefi-backend/UnitTests` to ensure the correct path is used for generating documentation.