### PR TITLE
Fixed docs Generation Frontend 

### DIFF
--- a/isopruefi-frontend/tsconfig.app.json
+++ b/isopruefi-frontend/tsconfig.app.json
@@ -19,7 +19,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
+    "erasableSyntaxOnly": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
This pull request modifies the TypeScript configuration in the `isopruefi-frontend` project to adjust the behavior of the compiler. The most notable change is the alteration of the `erasableSyntaxOnly` option.

### TypeScript configuration update:

* [`isopruefi-frontend/tsconfig.app.json`](diffhunk://#diff-cafb47ae58876ff47439cec8ab150fe7ddc4f764e596785c6ecec46d956f6787L22-R22): Changed the `erasableSyntaxOnly` option from `true` to `false`, likely to ensure that non-erasable syntax is allowed in the compiled output.