### PR TITLE
Fix/fix docker container generation

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,59 +1,105 @@
-#
 name: Release Docker Containers
 
-# Configures this workflow to run every time a change is pushed to the branch called `release`.
+# Triggers on git tags starting with 'v' for proper release versioning
 on:
   push:
 
-# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
-# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
-  build-and-push-image:
+  build-and-push-images:
     runs-on: ubuntu-latest
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
-      #
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+        
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-      - name: Build and push Docker image
-        id: push
+
+      # Build and push Frontend
+      - name: Build & push Frontend
+        id: push-frontend
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ./isopruefi-frontend
+          file: ./isopruefi-frontend/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      
-      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
-      - name: Generate artifact attestation
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-frontend:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-frontend:latest
+
+      # Build and push Rest-API
+      - name: Build & push Rest-API
+        id: push-api
+        uses: docker/build-push-action@v6
+        with:
+          context: ./isopruefi-backend
+          file: ./isopruefi-backend/Rest-API/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-rest-api:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-rest-api:latest
+
+      # Build and push Weather Data Worker
+      - name: Build & push Weather Data Worker
+        id: push-weather
+        uses: docker/build-push-action@v6
+        with:
+          context: ./isopruefi-backend
+          file: ./isopruefi-backend/Get-weatherData-worker/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-weather-worker:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-weather-worker:latest
+
+      # Build and push MQTT Receiver Worker
+      - name: Build & push MQTT Receiver Worker
+        id: push-mqtt
+        uses: docker/build-push-action@v6
+        with:
+          context: ./isopruefi-backend
+          file: ./isopruefi-backend/MQTT-Receiver-Worker/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-mqtt-worker:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-mqtt-worker:latest
+
+      # Generate artifact attestations for all images
+      - name: Generate Frontend attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-frontend
+          subject-digest: ${{ steps.push-frontend.outputs.digest }}
           push-to-registry: true
-      
+
+      - name: Generate API attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-rest-api
+          subject-digest: ${{ steps.push-api.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate Weather Worker attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-weather-worker
+          subject-digest: ${{ steps.push-weather.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate MQTT Worker attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-mqtt-worker
+          subject-digest: ${{ steps.push-mqtt.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,6 +1,6 @@
 name: Release Docker Containers
 
-# Triggers on git tags starting with 'v' for proper release versioning
+# Triggers on pushes to main or release branches
 on:
   push:
 
@@ -36,7 +36,7 @@ jobs:
           file: ./isopruefi-frontend/Dockerfile
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-frontend:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-frontend:${{ github.run_number }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-frontend:latest
 
       # Build and push Rest-API
@@ -48,7 +48,7 @@ jobs:
           file: ./isopruefi-backend/Rest-API/Dockerfile
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-rest-api:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-rest-api:${{ github.run_number }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-rest-api:latest
 
       # Build and push Weather Data Worker
@@ -60,7 +60,7 @@ jobs:
           file: ./isopruefi-backend/Get-weatherData-worker/Dockerfile
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-weather-worker:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-weather-worker:${{ github.run_number }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-weather-worker:latest
 
       # Build and push MQTT Receiver Worker
@@ -72,7 +72,7 @@ jobs:
           file: ./isopruefi-backend/MQTT-Receiver-Worker/Dockerfile
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-mqtt-worker:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-mqtt-worker:${{ github.run_number }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-mqtt-worker:latest
 
       # Generate artifact attestations for all images
@@ -102,4 +102,4 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/isopruefi-mqtt-worker
           subject-digest: ${{ steps.push-mqtt.outputs.digest }}
-          push-to-registry: true
+ 

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,67 +1,59 @@
-# .github/workflows/release-containers.yml
+#
 name: Release Docker Containers
 
-permissions:
-  contents: read
-
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches:
-      - 'main'
-      - 'sprint*'    # matches sprint0, sprint1, etc
 
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
-  build-and-push:
+  build-and-push-image:
     runs-on: ubuntu-latest
-
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Log in to GitHub Container Registry
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Build & push Rest-API
-        uses: docker/build-push-action@v4
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          working-directory: ./isopruefi-backend
-          file: Rest-API/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/Rest-API:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/Rest-API:latest
-
-      - name: Build & push MQTT-Receiver-Worker
-        uses: docker/build-push-action@v4
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
         with:
-          working-directory: ./isopruefi-backend
-          file: MQTT-Receiver-Worker/Dockerfile
+          context: .
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/MQTT-Receiver-Worker:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/MQTT-Receiver-Worker:latest
-
-      - name: Build & push Get Weather Worker 
-        uses: docker/build-push-action@v4
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
         with:
-          working-directory: ./isopruefi-backend
-          file: Get-weatherData-worker/Dockerfile 
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/Get-weatherData-worker:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/Get-weatherData-worker:latest
-
-      - name: Build & push Frontend
-        uses: docker/build-push-action@v4
-        with:
-          working-directory: ./isopruefi-frontend
-          file: Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/frontend:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/frontend:latest
-            
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releasing Docker containers, improving its structure, functionality, and security. The changes include renaming jobs, enhancing environment variable usage, updating Docker build configurations, and adding artifact attestation steps for improved traceability.

### Workflow Improvements:

* Renamed the job from `build-and-push` to `build-and-push-images` for better clarity and updated the trigger conditions to remove sprint branch patterns.  
* Introduced a global `REGISTRY` environment variable for consistent registry references across the workflow.  
* Updated permissions to include `packages: write`, `attestations: write`, and `id-token: write` for enhanced security and functionality.

### Docker Build and Push Enhancements:

* Reorganized and updated the Docker build configurations for the `Frontend`, `Rest-API`, `Weather Data Worker`, and `MQTT Receiver Worker` to use `docker/build-push-action@v6`, ensuring consistency and specifying explicit contexts and Dockerfiles.  
* Changed image tagging to use `${{ env.REGISTRY }}` and `${{ github.run_number }}` for better traceability and standardization.

### Artifact Attestation:

* Added steps to generate build provenance attestations for all Docker images (`Frontend`, `Rest-API`, `Weather Data