### PR TITLE
Fix npm docs issue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Generate Arduino Documentation
         working-directory: ./arduino
         run: doxygen Doxyfile
+        
+      - name: Install npm dependencies
+        run: npm ci
        
       - name: Generate Arduino Documentation
         working-directory: ./isopruefi-docs/docs/code/arduino


### PR DESCRIPTION
This pull request adds a step to the documentation workflow to ensure Node.js dependencies are installed before generating Arduino documentation.

Documentation workflow update:

* Added a new job step to install npm dependencies using `npm ci` in the `.github/workflows/docs.yml` file, ensuring that all required packages are available before running documentation generation commands.