### PR TITLE
fix: fixed frontend docker

### DIFF
--- a/isopruefi-frontend/Dockerfile-Dev
+++ b/isopruefi-frontend/Dockerfile-Dev
@@ -4,8 +4,8 @@ FROM node:24-alpine
 # Set the working directory inside the container
 WORKDIR /app
  
-# Copy package.json
-COPY package.json .
+# Copy package.json and package-lock.json
+COPY package*.json ./
  
 # Install dependencies
 RUN npm install
@@ -13,6 +13,8 @@ RUN npm install
 # Copy the rest of your application files
 COPY . .
 
-# Define the command to run your app
-CMD ["npm", "run", "dev"]
+# Expose the port that Vite dev server runs on
+EXPOSE 5173
 
+# Define the command to run your app with host binding
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
This pull request updates the `Dockerfile-Dev` for the frontend to improve Docker development workflow. The main changes ensure all dependencies are installed correctly and the development server is accessible from outside the container.

Dockerfile improvements:

* Now copies both `package.json` and `package-lock.json` to ensure consistent dependency installs.
* Exposes port 5173, which is the default for the Vite dev server, making the app accessible from the host machine.
* Updates the `CMD` to run the dev server on all network interfaces (`--host 0.0.0.0`), allowing access from outside the container.