### PR TITLE
feat: add database migration application in Program.cs

### DIFF
--- a/isopruefi-backend/Get-weatherData-worker/Program.cs
+++ b/isopruefi-backend/Get-weatherData-worker/Program.cs
@@ -43,6 +43,9 @@ public class Program
 
         var app = builder.Build();
 
+        using var scope = ((IApplicationBuilder)app).ApplicationServices.CreateScope();
+        ApplicationDbContext.ApplyMigration<ApplicationDbContext>(scope);
+
         // Configure health check endpoints
         app.MapHealthChecks("/health", new HealthCheckOptions
         {

--- a/isopruefi-backend/MQTT-Receiver-Worker/Program.cs
+++ b/isopruefi-backend/MQTT-Receiver-Worker/Program.cs
@@ -50,6 +50,9 @@ public class Program
 
         var app = builder.Build();
 
+        using var scope = ((IApplicationBuilder)app).ApplicationServices.CreateScope();
+        ApplicationDbContext.ApplyMigration<ApplicationDbContext>(scope);
+
         //HealthCheck Middleware
         app.MapHealthChecks("/health", new HealthCheckOptions
         {


### PR DESCRIPTION
This pull request introduces an important change to both the `Get-weatherData-worker` and `MQTT-Receiver-Worker` projects to ensure that database migrations are applied automatically at application startup. This helps keep the database schema in sync with the application's expectations, reducing the risk of runtime errors due to schema mismatches.

**Database Migration on Startup:**

* Added code in `Program.cs` for both `Get-weatherData-worker` and `MQTT-Receiver-Worker` to create a service scope and apply pending migrations to the `ApplicationDbContext` when the application starts. [[1]](diffhunk://#diff-82d89f08f76904896869a7a932e35257bd91639655036759af0b6e52576abf02R46-R48) [[2]](diffhunk://#diff-cf22f73ad623ae98bac23e7b0e383a045ed83a5f2a6c077af23063fbeb1b6826R53-R55)