### PR TITLE
Feat/add cache for influx

### DIFF
--- a/isopruefi-backend/Database/Repository/InfluxRepo/CachedInfluxHealthCheck.cs
+++ b/isopruefi-backend/Database/Repository/InfluxRepo/CachedInfluxHealthCheck.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Database.Repository.InfluxRepo;
+
+/// <summary>
+/// Enhanced health check for InfluxDB connectivity and cache status.
+/// Provides information about both InfluxDB connectivity and cached writes.
+/// </summary>
+public class CachedInfluxHealthCheck : IHealthCheck
+{
+    private readonly CachedInfluxRepo _cachedInfluxRepo;
+    private readonly ILogger<CachedInfluxHealthCheck> _logger;
+
+    /// <summary>
+    /// Constructor for the CachedInfluxHealthCheck class.
+    /// </summary>
+    /// <param name="cachedInfluxRepo">The cached InfluxDB repository.</param>
+    /// <param name="logger">The logger instance.</param>
+    public CachedInfluxHealthCheck(CachedInfluxRepo cachedInfluxRepo, ILogger<CachedInfluxHealthCheck> logger)
+    {
+        _cachedInfluxRepo = cachedInfluxRepo ?? throw new ArgumentNullException(nameof(cachedInfluxRepo));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Checks the health of the InfluxDB connection and cache status.
+    /// </summary>
+    /// <param name="context">The health check context.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A health check result indicating the status of InfluxDB and cache.</returns>
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Check cached points count
+            var cachedPoints = _cachedInfluxRepo.GetCachedPoints();
+            var cachedCount = cachedPoints.Count;
+
+            // Perform a simple query to check InfluxDB connectivity
+            var testStart = DateTime.UtcNow.AddMinutes(-1);
+            var testEnd = DateTime.UtcNow;
+
+            var query = _cachedInfluxRepo.GetSensorWeatherData(testStart, testEnd);
+            await using var enumerator = query.GetAsyncEnumerator(cancellationToken);
+            var hasData = await enumerator.MoveNextAsync();
+
+            var data = new Dictionary<string, object>
+            {
+                ["influxdb_connected"] = true,
+                ["cached_points_count"] = cachedCount,
+                ["has_recent_data"] = hasData
+            };
+
+            if (cachedCount > 0)
+            {
+                _logger.LogWarning("InfluxDB is connected but {CachedCount} points are still cached", cachedCount);
+
+                return HealthCheckResult.Degraded(
+                    $"InfluxDB connected but {cachedCount} cached writes pending", 
+                    data: data);
+            }
+
+            _logger.LogDebug("InfluxDB health check completed successfully. No cached points");
+            return HealthCheckResult.Healthy("InfluxDB connection is healthy, no cached writes", data);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return HealthCheckResult.Unhealthy("InfluxDB health check timed out");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"InfluxDB connection failed: {ex.Message}.", ex);
+        }
+    }
+}

--- a/isopruefi-backend/Database/Repository/InfluxRepo/InfluxRetryService.cs
+++ b/isopruefi-backend/Database/Repository/InfluxRepo/InfluxRetryService.cs
@@ -1,0 +1,134 @@
+using Database.Repository.InfluxRepo;
+using InfluxDB3.Client.Write;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Database.Repository.InfluxRepo;
+
+/// <summary>
+/// Background service that periodically retries failed InfluxDB writes from the memory cache.
+/// Runs every 5 minutes to attempt flushing cached PointData objects to InfluxDB.
+/// </summary>
+public class InfluxRetryService : BackgroundService
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<InfluxRetryService> _logger;
+    private readonly TimeSpan _retryInterval = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Constructor for the InfluxRetryService.
+    /// </summary>
+    /// <param name="serviceScopeFactory">Factory for creating service scopes</param>
+    /// <param name="logger">Logger instance</param>
+    public InfluxRetryService(IServiceScopeFactory serviceScopeFactory, ILogger<InfluxRetryService> logger)
+    {
+        _serviceScopeFactory = serviceScopeFactory ?? throw new ArgumentNullException(nameof(serviceScopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Main execution loop for the background service.
+    /// </summary>
+    /// <param name="stoppingToken">Cancellation token</param>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("InfluxDB retry service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RetryFailedWrites();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred during InfluxDB retry operation");
+            }
+
+            await Task.Delay(_retryInterval, stoppingToken);
+        }
+
+        _logger.LogInformation("InfluxDB retry service stopped");
+    }
+
+    /// <summary>
+    /// Attempts to retry all cached PointData writes to InfluxDB.
+    /// </summary>
+    private async Task RetryFailedWrites()
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var cachedInfluxRepo = scope.ServiceProvider.GetService<CachedInfluxRepo>();
+        
+        if (cachedInfluxRepo == null)
+        {
+            _logger.LogWarning("CachedInfluxRepo not available for retry operation");
+            return;
+        }
+
+        var cachedPoints = cachedInfluxRepo.GetCachedPoints();
+        
+        if (cachedPoints.Count == 0)
+        {
+            _logger.LogDebug("No cached points to retry");
+            return;
+        }
+
+        _logger.LogInformation("Attempting to retry {Count} cached InfluxDB writes", cachedPoints.Count);
+
+        int successCount = 0;
+        int failureCount = 0;
+
+        foreach (var kvp in cachedPoints)
+        {
+            try
+            {
+                await RetryPointWrite(cachedInfluxRepo, kvp.Key, kvp.Value);
+                successCount++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to retry cached point {CacheKey}", kvp.Key);
+                failureCount++;
+            }
+        }
+
+        _logger.LogInformation(
+            "Retry operation completed. Success: {SuccessCount}, Failed: {FailureCount}", 
+            successCount, failureCount);
+    }
+
+    /// <summary>
+    /// Attempts to retry writing a single cached PointData object to InfluxDB.
+    /// </summary>
+    /// <param name="cachedRepo">The cached repository instance</param>
+    /// <param name="cacheKey">Cache key for the point</param>
+    /// <param name="point">The PointData to write</param>
+    private async Task RetryPointWrite(CachedInfluxRepo cachedRepo, object cacheKey, PointData point)
+    {
+        try
+        {
+            // Use reflection to access the private _client field
+            var clientField = typeof(CachedInfluxRepo).GetField("_client", 
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            
+            if (clientField?.GetValue(cachedRepo) is InfluxDB3.Client.InfluxDBClient client)
+            {
+                await client.WritePointAsync(point);
+                cachedRepo.RemoveCachedPoint(cacheKey);
+                
+                _logger.LogDebug("Successfully retried cached point {CacheKey}", cacheKey);
+            }
+            else
+            {
+                _logger.LogError("Could not access InfluxDB client for retry operation");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Retry failed for cached point {CacheKey}, will try again later", cacheKey);
+            throw;
+        }
+    }
+}

--- a/isopruefi-backend/MQTT-Receiver-Worker/HealthCheck.cs
+++ b/isopruefi-backend/MQTT-Receiver-Worker/HealthCheck.cs
@@ -13,6 +13,6 @@ public static class HealthCheck
             .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection") ?? string.Empty, "select 1",
                 name: "PostgreSQL", failureStatus: HealthStatus.Unhealthy, tags: new[] { "Database" })
             .AddCheck<MqttHealthCheck>("MQTT Connection", HealthStatus.Unhealthy, new[] { "MQTT" })
-            .AddCheck<InfluxHealthCheck>("InfluxDB", HealthStatus.Unhealthy, new[] { "Database" });
+            .AddCheck<CachedInfluxHealthCheck>("InfluxDB", HealthStatus.Unhealthy, new[] { "Database" });
     }
 }

--- a/isopruefi-backend/MQTT-Receiver-Worker/MQTT/Receiver.cs
+++ b/isopruefi-backend/MQTT-Receiver-Worker/MQTT/Receiver.cs
@@ -56,7 +56,12 @@ public class Receiver : IReceiver
 
             foreach (var topic in topics)
             {
+#if DEBUG
+                var groupName = "cute-temp-dev-group2";
+#else
                 var groupName = "cute-temp-group2";
+#endif
+
                 var sharedTopic =
                     $"$share/{groupName}/{topic.DefaultTopicPath}/{topic.GroupId}/{topic.SensorType}/{topic.SensorName}";
 

--- a/isopruefi-backend/MQTT-Receiver-Worker/Program.cs
+++ b/isopruefi-backend/MQTT-Receiver-Worker/Program.cs
@@ -48,6 +48,7 @@ public class Program
         else if (builder.Environment.IsEnvironment("Docker")) builder.Configuration.AddEnvironmentVariables();
 
         builder.Services.AddHostedService<Worker>();
+        builder.Services.AddHostedService<InfluxRetryService>();
 
         var app = builder.Build();
 

--- a/isopruefi-backend/MQTT-Receiver-Worker/Program.cs
+++ b/isopruefi-backend/MQTT-Receiver-Worker/Program.cs
@@ -25,11 +25,12 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        builder.Services.AddScoped<IInfluxRepo, InfluxRepo>();
+        builder.Services.AddMemoryCache();
 
         // Register Repos
+        builder.Services.AddScoped<CachedInfluxRepo>();
+        builder.Services.AddScoped<IInfluxRepo>(provider => provider.GetRequiredService<CachedInfluxRepo>());
         builder.Services.AddScoped<ISettingsRepo, SettingsRepo>();
-
         // Register Database with proper DbContext
         builder.Services.AddDbContext<ApplicationDbContext>(options =>
         {


### PR DESCRIPTION
This pull request introduces a robust caching and retry mechanism for InfluxDB writes, enhancing reliability when the database is unavailable. It replaces the previous `InfluxRepo` with a new `CachedInfluxRepo` that buffers failed writes in memory and adds a background service to periodically retry these writes. The health check for InfluxDB is also updated to reflect both connectivity and cache status.

**InfluxDB Write Caching and Retry Mechanism**

* Added `CachedInfluxRepo`, which wraps InfluxDB operations with write-through caching. Failed writes are buffered in memory and retried later. (`isopruefi-backend/Database/Repository/InfluxRepo/CachedInfluxRepo.cs`)
* Introduced `InfluxRetryService`, a background service that periodically attempts to flush cached writes to InfluxDB. (`isopruefi-backend/Database/Repository/InfluxRepo/InfluxRetryService.cs`)
* Updated service registration to use `CachedInfluxRepo` for all `IInfluxRepo` dependencies and enabled memory caching. (`isopruefi-backend/MQTT-Receiver-Worker/Program.cs`)
* Registered `InfluxRetryService` as a hosted service to enable automatic retry of failed writes. (`isopruefi-backend/MQTT-Receiver-Worker/Program.cs`)

**Health Check Improvements**

* Replaced the old InfluxDB health check with `CachedInfluxHealthCheck`, which reports both InfluxDB connectivity and the number of cached (pending) writes. (`isopruefi-backend/Database/Repository/InfluxRepo/CachedInfluxHealthCheck.cs`, `isopruefi-backend/MQTT-Receiver-Worker/HealthCheck.cs`) [[1]](diffhunk://#diff-11e47cfc6bcd3722675fc02b9a1f290ccac1062423ecba3c2f38a82290915f8bR1-R78) [[2]](diffhunk://#diff-df853e32f440597a86183346fe77d1df7c0c2cd664f74109d3ae844ff70ec56fL16-R16)

**Miscellaneous**

* Updated MQTT topic group name for debug builds to aid development and testing. (`isopruefi-backend/MQTT-Receiver-Worker/MQTT/Receiver.cs`)