### PR TITLE
fix: update PDF cover page details in mkdocs configuration

### DIFF
--- a/isopruefi-docs/mkdocs.yml
+++ b/isopruefi-docs/mkdocs.yml
@@ -1,7 +1,5 @@
 site_name: IsoPrüfi
-subtitle: Documentation
-author: "Manuel Schülein, Mara Küfer, Danylo Tulainov, Diana Huynh"
-date: "September 2025"
+site_author: Manuel Schülein, Mara Küfer, Danylo Tulainov, Diana Huynh
 copyright: " "
 docs_dir: ./docs
 site_url: https://deadmade.github.io/IsoPruefi/
@@ -90,7 +88,12 @@ plugins:
   - callouts
   - render_swagger:
       allow_arbitrary_locations: true
-  - to-pdf
+  - to-pdf:
+      cover_title: "IsoPrüfi"
+      cover_subtitle: "Documentation"
+      cover_author: "Manuel Schülein, Mara Küfer, Danylo Tulainov, Diana Huynh"
+      cover_date: "September 2025"
+
 markdown_extensions:
   - pymdownx.extra
   - pymdownx.highlight


### PR DESCRIPTION

This pull request updates the MkDocs configuration for the IsoPrüfi documentation site. The most significant changes involve improving metadata handling and enhancing the PDF export plugin setup.

**Metadata improvements:**

* Replaced the deprecated `subtitle`, `author`, and `date` fields with a consolidated `site_author` field for clearer site metadata in `mkdocs.yml`.

**PDF export enhancements:**

* Updated the `to-pdf` plugin configuration to include custom cover details such as title, subtitle, author, and date, ensuring exported PDFs have accurate and branded cover pages.